### PR TITLE
Configure api key

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,20 @@
+# Class: dell_info
+#
+# api_key = the api key to use when quering dell
+# extra_facts = list of additional facts to identify dell servers
+class dell_info (
+  $api_key     = undef,
+  $force       = false,
+  $extra_facts = [],
+) {
+  validate_string($api_key)
+  validate_bool($force)
+  validate_array($extra_facts)
+  file {'/etc/dell_info.yaml':
+    ensure  => present,
+    content => template('dell_info/etc/dell_info.yaml.erb'),
+  }
+  file {'/var/cache/facts.d':
+    ensure => directory,
+  }
+}

--- a/templates/etc/dell_info.yaml.erb
+++ b/templates/etc/dell_info.yaml.erb
@@ -1,0 +1,8 @@
+---
+api_key: <%= @api_key %>
+force: <%= @force %>
+extra_facts: 
+<%- @extra_facts.each do |fact| -%>
+- <%= fact %>
+<%- end -%>
+


### PR DESCRIPTION
Add the ability to specify an api key.  I have also added two new variables
  force: if true dell_info will try the dell api even if it cant detect a machine is dell
  extra_facts:  this is an array of facts which may contain info identifying a machine as dell.  This was needed for dell appliances which had a blank manufacture 