### PR TITLE
Add params, use open-uri

### DIFF
--- a/lib/facter/dell_info.rb
+++ b/lib/facter/dell_info.rb
@@ -84,7 +84,7 @@ if Facter.value('manufacturer')
     #  If no cache file, or cache file is expired, query Dell.
     if !dell_cache || (Time.now - cache_time) > cache_ttl
       #url = url % [apikey, Facter.value('serialnumber')]
-      #begin
+      begin
         Timeout::timeout(30) {
           Facter.debug('Getting api.dell.com')
           request_uri=url

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@ class dell_info (
   String            $api_url      = $::dell_info::params::api_url,
   String            $cache_dir    = $::dell_info::params::cache_dir,
   Integer           $cache_ttl    = $::dell_info::params::cache_ttl,
-) {
+  ) inherits ::dell_info::params {
 
   file {'/etc/dell_info.yaml':
     content => template('dell_info/etc/dell_info.yaml.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,18 +3,18 @@
 # api_key = the api key to use when quering dell
 # extra_facts = list of additional facts to identify dell servers
 class dell_info (
-  $api_key     = undef,
-  $force       = false,
-  $extra_facts = [],
+  Optional[String]  $apikey       = $::dell_info::params::apikey,
+  Boolean           $force        = $::dell_info::params::force,
+  Array             $extra_facts  = $::dell_info::params::extra_facts,
+  String            $api_url      = $::dell_info::params::api_url,
+  String            $cache_dir    = $::dell_info::params::cache_dir,
+  Integer           $cache_ttl    = $::dell_info::params::cache_ttl,
 ) {
-  validate_string($api_key)
-  validate_bool($force)
-  validate_array($extra_facts)
+
   file {'/etc/dell_info.yaml':
-    ensure  => present,
     content => template('dell_info/etc/dell_info.yaml.erb'),
   }
-  file {'/var/cache/facts.d':
+  file { $cache_dir:
     ensure => directory,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,7 @@
 # api_key = the api key to use when quering dell
 # extra_facts = list of additional facts to identify dell servers
 class dell_info (
-  Optional[String]  $apikey       = $::dell_info::params::apikey,
+  Optional[String]  $api_key       = $::dell_info::params::api_key,
   Boolean           $force        = $::dell_info::params::force,
   Array             $extra_facts  = $::dell_info::params::extra_facts,
   String            $api_url      = $::dell_info::params::api_url,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,7 @@
 class dell_info::params {
-  $api_key = undef,
-  $force = false,
-  $extra_facts = [],
+  $api_key = undef
+  $force = false
+  $extra_facts = []
   $api_url = 'https://api.dell.com/support/v2/assetinfo/warranty/tags.json'
   $cache_dir = '/var/cache/facts.d'
   $cache_ttl = 604800

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,8 @@
+class dell_info::params {
+  $api_key = undef,
+  $force = false,
+  $extra_facts = [],
+  $api_url = 'https://api.dell.com/support/v2/assetinfo/warranty/tags.json'
+  $cache_dir = '/var/cache/facts.d'
+  $cache_ttl = 604800
+}

--- a/templates/etc/dell_info.yaml.erb
+++ b/templates/etc/dell_info.yaml.erb
@@ -1,8 +1,10 @@
 ---
 api_key: <%= @api_key %>
+api_url: <%= @api_url %>
 force: <%= @force %>
-extra_facts: 
+cache_dir: <%= @cache_dir %>
+cache_ttl: <%= @cache_ttl %>
+extra_facts:
 <%- @extra_facts.each do |fact| -%>
 - <%= fact %>
 <%- end -%>
-


### PR DESCRIPTION
This PR does a few things: 
- Adds a params.pp with new parameters allowing the end user to set the cache_dir, cache_ttl, and api_url (there is a sandbox.api ). This moves the defaults to params.pp per usual and init.pp inherits from that. 
- Swaps out how the fact talks to the api, officially from Dell sending the apikey in the URL is a no-no, and the api can accept the apikey in the headers, so this swaps out the http work for a method that does that. 
- Otherwise just sets up the fact to use the cache_dir + ttl from the config written, as well as the api_url. 

(FYI, a private PAI key can be obtained by asking dell, there is a...enrollment process) 
