### PR TITLE
Better match dependency markup

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.0"}
   ]
 }
 


### PR DESCRIPTION
Match https://docs.puppet.com/puppet/3/reference/modules_publishing.html#dependencies-in-the-modulefile.
Otherwise, puppet shows false warning:

```
# puppet module list -v
Warning: Missing dependency 'puppetlabs-stdlib':
  'kwolf-dell_info' (v1.5.1) requires 'puppetlabs-stdlib' (>= 1.0.0)
/etc/puppet/modules
└── kwolf-dell_info (v1.5.1)
/usr/share/puppet/modules
```
