### PR TITLE
Dell APIv4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#Puppet dell_info
+# Puppet dell_info
 
-##Overview
+## Overview
 
 This puppet module adds custom facts aquired by querying https://api.dell.com/. It supports the v4 API.
 
-##Module Description
+## Module Description
 
 We use this to track the age of our mission critical production servers.
 
@@ -48,28 +48,30 @@ dell_info::sandbox: true
 dell_info::api_key: "abcde1234"
 ```
 
-##Limitations
+## Limitations
 
 * Currently dell_info only supports Linux based operating systems.  We've used it on CentOS, RedHat, Ubuntu and Proxmox (Debian).
 ** Wouldn't take much to make this work on Windows.  Right now I'm using curl instead of net http.  Also the cache directory would need to chnage. It's pretty Linux specific right now.
 * Only runs on Dell bare metal servers.
 * Will only query Dell for hardware based servers which have serial numbers Facter can see.
 
-##Author
+## Author
 
 Kevin Wolf
 kwolf72@gmail.com
 
 V4 and sandbox support : 
-
 Jonathan Schaeffer
 jonathan.schaeffer@univ-brest.fr
 
-##Support
+## Support
 
 Please log tickets and issues at the [github repository](https://github.com/kwolf/dell_info/issues)
 
-##Release notes
+## Release notes
+
+### 4.1.0
+* Adding warranty_end fact
 
 ### 4.0.0
 * Switching to v4 API, sticking major version to the API version

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ##Overview
 
-This puppet module adds custom facts aquired by querying https://api.dell.com/.
+This puppet module adds custom facts aquired by querying https://api.dell.com/. It supports the v4 API.
 
 ##Module Description
 
-We use this to track the age of our mission critical production servers. 
+We use this to track the age of our mission critical production servers.
 
 Facts are cached for seven days by default.
 
@@ -29,10 +29,18 @@ Custom facts added, may very based on your warranty details:
 
 The _warranty_ fact should be set to _warranty => true_ if any warranties are greater than the current date, and _warranty => false_ if all warranties have expired.
 
-api.dell.com uses API keys.  When I wrote this there were three publically available on the internet.  This isn't a private key that's currently in the module.  In fact, I couldn't find a way to get a private key.
+api.dell.com uses API keys. To get one for your use, follow [Dell's instructions](http://en.community.dell.com/dell-groups/supportapisgroup/).
 
-Based on this [blog article](http://ocdnix.wordpress.com/2013/02/28/pulling-warranty-details-from-api-dell-com/) about api.dell.com. 
+Your API key will first only work on Dell's sandbox api server. You should ask your contact to promote it in their production API.
 
+You can test your key with the sandbox API using the parameter :
+
+```
+class{'dell_info': 
+   sandbox => true,
+   api_key => "abcde1234"
+}
+```
 
 ##Limitations
 
@@ -46,11 +54,19 @@ Based on this [blog article](http://ocdnix.wordpress.com/2013/02/28/pulling-warr
 Kevin Wolf
 kwolf72@gmail.com
 
+V4 and sandbox support : 
+
+Jonathan Schaeffer
+jonathan.schaeffer@univ-brest.fr
+
 ##Support
 
 Please log tickets and issues at the [github repository](https://github.com/kwolf/dell_info/issues)
 
 ##Release notes
+
+### 4.0.0
+* Switching to v4 API, sticking major version to the API version
 
 ### 1.0.1
 * Forgot to increment the version number in the module file.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ class{'dell_info':
    api_key => "abcde1234"
 }
 ```
+or in hiera :
+
+```
+dell_info::sandbox: true
+dell_info::api_key: "abcde1234"
+```
 
 ##Limitations
 

--- a/lib/facter/dell_info.rb
+++ b/lib/facter/dell_info.rb
@@ -9,7 +9,7 @@ config = Hash.new
 
 #  URL used to query Dell's API
 # For testing purpose I use sandbox but in production, this should be changed
-url = 'https://sandbox.api.dell.com/support/assetinfo/v4/getassetheader/%s?apikey=%s'
+url = 'https://sandbox.api.dell.com/support/assetinfo/v4/getassetwarranty/%s?apikey=%s'
 
 # This dummy key might not work
 apikey = '1adecee8a60444738f280aad1cd87d0e'

--- a/lib/facter/dell_info.rb
+++ b/lib/facter/dell_info.rb
@@ -125,9 +125,12 @@ if Facter.value('manufacturer')
         warranties = [warranties] unless warranties.is_a? Array
         covered = false
 
+        warranty_end = Date.new(1970)
         warranties.each_with_index do |warranty,index|
           enddate = Date.parse(warranty['EndDate'])
           covered = (enddate > Date.parse(Time.now.to_s)) if covered == false
+          warranty_end = enddate unless warranty_end > enddate
+          
           Facter.add("warranty#{index}_expires") do
             setcode do
               enddate.to_s
@@ -150,6 +153,11 @@ if Facter.value('manufacturer')
         Facter.add(:warranty) do
           setcode do
             covered
+          end
+        end
+        Facter.add(:warranty_end) do
+          setcode do
+            warranty_end
           end
         end
       rescue Exception=>e

--- a/lib/facter/dell_info.rb
+++ b/lib/facter/dell_info.rb
@@ -9,7 +9,7 @@ config = Hash.new
 
 #  URL used to query Dell's API
 # For testing purpose I use sandbox but in production, this should be changed
-url = 'https://sandbox.api.dell.com/support/assetinfo/v4/getassetwarranty/%s?apikey=%s'
+url = 'https://api.dell.com/support/assetinfo/v4/getassetwarranty/%s?apikey=%s'
 
 # This dummy key might not work
 apikey = '1adecee8a60444738f280aad1cd87d0e'
@@ -26,6 +26,9 @@ if File.exists?(conf_file) then
   end
   if config['force'] then
     dell_machine = true
+  end
+  if config['sandbox'] then
+    uri.host = 'sandbox.'+uri.host
   end
   if config['extra_facts'] then
     config['extra_facts'].each do |fact|

--- a/lib/facter/dell_info.rb
+++ b/lib/facter/dell_info.rb
@@ -10,7 +10,7 @@ config = Hash.new
 #  URL used to query Dell's API
 # For testing purpose I use sandbox but in production, this should be changed
 url = 'https://api.dell.com/support/assetinfo/v4/getassetwarranty/%s?apikey=%s'
-
+use_sandbox = false
 # This dummy key might not work
 apikey = '1adecee8a60444738f280aad1cd87d0e'
 dell_machine = false
@@ -27,9 +27,7 @@ if File.exists?(conf_file) then
   if config['force'] then
     dell_machine = true
   end
-  if config['sandbox'] then
-    uri.host = 'sandbox.'+uri.host
-  end
+  use_sandbox = config['sandbox']
   if config['extra_facts'] then
     config['extra_facts'].each do |fact|
       if Facter.value(fact) =~ /dell/i then
@@ -79,7 +77,10 @@ if Facter.value('manufacturer')
         Timeout::timeout(30) {
           Facter.debug('Getting api.dell.com')
           uri = URI(url)
+          uri.host = 'sandbox.'+uri.host if use_sandbox
+          Facter.debug(uri.host)
           http = Net::HTTP.new(uri.host, uri.port)
+          Facter.debug(uri.host)
           http.use_ssl = true
           request = Net::HTTP::Get.new(uri.request_uri)
           response = http.request(request)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,11 +4,13 @@
 # extra_facts = list of additional facts to identify dell servers
 class dell_info (
   $api_key     = undef,
+  $sandbox     = false,
   $force       = false,
   $extra_facts = [],
 ) {
   validate_string($api_key)
   validate_bool($force)
+  validate_bool($sandbox)
   validate_array($extra_facts)
   file {'/etc/dell_info.yaml':
     ensure  => present,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "kwolf-dell_info",
-  "version": "1.5.1",
+  "version": "4.0.0",
   "author": "kwolf",
   "summary": "Module to pull warranty information from Dell's API.",
   "license": "Apache 2.0",
@@ -16,6 +16,10 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [ "12.04", "10.04" ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [ "7", "8" ]
     }
   ],
   "dependencies": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "kwolf-dell_info",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": "kwolf",
   "summary": "Module to pull warranty information from Dell's API.",
   "license": "Apache 2.0",
@@ -15,11 +15,11 @@
     },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [ "12.04", "10.04" ]
+        "operatingsystemrelease": [ "12.04", "10.04", "14.04", "16.04" ]
     },
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": [ "7", "8" ]
+        "operatingsystemrelease": [ "7", "8", "9" ]
     }
   ],
   "dependencies": [

--- a/templates/etc/dell_info.yaml.erb
+++ b/templates/etc/dell_info.yaml.erb
@@ -1,6 +1,7 @@
 ---
 api_key: <%= @api_key %>
 force: <%= @force %>
+sandbox: <%= @sandbox %>
 extra_facts: 
 <%- @extra_facts.each do |fact| -%>
 - <%= fact %>


### PR DESCRIPTION
The Dell API has changed and I had to adapt this module.

I also added an option to use the Dell sandbox API, usefull to test the API key.

I suggest sticking the major version of this module with the API version.

Thank you for this great module ! It's realy helpfull
